### PR TITLE
core: add base UI scaffold

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
+    'django_filters',
     "accounts",
     "catalog",
     "crm",
@@ -64,7 +66,7 @@ ROOT_URLCONF = 'config.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / "templates"],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -114,7 +116,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Africa/Ouagadougou'
 
 USE_I18N = True
 
@@ -124,7 +126,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
+STATICFILES_DIRS = [BASE_DIR / 'static']
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,7 +16,14 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.views.generic import TemplateView
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
+    path('', TemplateView.as_view(template_name="home.html"), name="home"),
     path('admin/', admin.site.urls),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,15 @@
+/* Basic reset */
+body { margin: 0; font-family: Arial, sans-serif; }
+
+.navbar { background: #333; padding: 1rem; }
+.navbar a { color: #fff; margin-right: 1rem; text-decoration: none; }
+
+.container { padding: 1rem; }
+
+.messages { list-style: none; padding: 0; }
+.messages li { margin: 0.5rem 0; padding: 0.5rem; }
+.messages li.success { background: #d4edda; color: #155724; }
+.messages li.error { background: #f8d7da; color: #721c24; }
+
+.table { width: 100%; border-collapse: collapse; }
+.table th, .table td { border: 1px solid #ccc; padding: 0.5rem; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const tables = document.querySelectorAll('table.datatable');
+  if (tables.length && window.jQuery && $.fn.DataTable) {
+    tables.forEach(function (table) {
+      $(table).DataTable();
+    });
+  }
+  // Future Chart.js logic will go here
+});

--- a/templates/400.html
+++ b/templates/400.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Erreur 400{% endblock %}
+{% block content %}
+<h1>Erreur 400</h1>
+<p>La requête est invalide.</p>
+<a href="{% url 'home' %}">Retour à l'accueil</a>
+{% endblock %}

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Erreur 403{% endblock %}
+{% block content %}
+<h1>Erreur 403</h1>
+<p>Vous n’avez pas accès à cette page.</p>
+<a href="{% url 'home' %}">Retour à l'accueil</a>
+{% endblock %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Erreur 404{% endblock %}
+{% block content %}
+<h1>Erreur 404</h1>
+<p>La page demandée est introuvable.</p>
+<a href="{% url 'home' %}">Retour à l'accueil</a>
+{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block title %}Erreur 500{% endblock %}
+{% block content %}
+<h1>Erreur 500</h1>
+<p>Une erreur interne est survenue.</p>
+<a href="{% url 'home' %}">Retour à l'accueil</a>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,29 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Assurance{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+    <link rel="stylesheet" href="{% static 'css/app.css' %}">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="{% static 'js/app.js' %}"></script>
+</head>
+<body>
+    <nav class="navbar">
+        <a href="#">Produits</a>
+        <a href="#">Assurés</a>
+        <a href="#">Contrats</a>
+        <a href="#">Sinistres</a>
+        <a href="#">Plaintes</a>
+        <a href="#">Imports</a>
+        <a href="#">Dashboard</a>
+    </nav>
+    <div class="container">
+        {% include 'includes/messages.html' %}
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Accueil{% endblock %}
+{% block content %}
+<h1>Plateforme Assurance</h1>
+<p>Application pédagogique de gestion d'assurance.</p>
+<table class="datatable">
+  <thead>
+    <tr><th>Colonne 1</th><th>Colonne 2</th><th>Colonne 3</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>A1</td><td>B1</td><td>C1</td></tr>
+    <tr><td>A2</td><td>B2</td><td>C2</td></tr>
+    <tr><td>A3</td><td>B3</td><td>C3</td></tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/includes/messages.html
+++ b/templates/includes/messages.html
@@ -1,0 +1,7 @@
+{% if messages %}
+<ul class="messages">
+  {% for message in messages %}
+  <li class="{{ message.tags }}">{{ message }}</li>
+  {% endfor %}
+</ul>
+{% endif %}


### PR DESCRIPTION
## Summary
- configure static and media settings and timezone
- create base layout, home page, messages include, and error templates
- add starter CSS/JS with DataTables initialization

## Testing
- `python manage.py runserver 0:8000 &` (accessed `/`)


------
https://chatgpt.com/codex/tasks/task_e_68a46f5890ec8324ae50a4ff641fa606