### PR TITLE
Add role-based workspaces with login redirect

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.views import PasswordChangeView, LogoutView
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
+from django.views import View
 
 
 class ForcePasswordChangeView(PasswordChangeView):
@@ -21,3 +23,22 @@ class SimpleLogoutView(LogoutView):
 
     def get(self, request, *args, **kwargs):  # pragma: no cover - thin wrapper
         return self.post(request, *args, **kwargs)
+
+
+class PostLoginRedirectView(View):
+    role_map = {
+        "dg": "/dashboard/dg/",
+        "rh": "/workspaces/rh/",
+        "actuaire": "/workspaces/actuaire/",
+        "commercial": "/workspaces/commercial/",
+        "redacteur": "/workspaces/redacteur/",
+        "gestionnaire": "/workspaces/gestionnaire/",
+        "comptable": "/workspaces/comptable/",
+    }
+
+    def get(self, request, *args, **kwargs):
+        user = request.user
+        for role, url in self.role_map.items():
+            if user.groups.filter(name=role).exists():
+                return redirect(url)
+        return redirect("/")

--- a/config/settings.py
+++ b/config/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "finance",
     "imports",
     "dashboard",
+    "workspaces",
     "audit",
 ]
 
@@ -135,7 +136,7 @@ MEDIA_ROOT = BASE_DIR / 'media'
 
 # Authentication settings
 LOGIN_URL = '/accounts/login/'
-LOGIN_REDIRECT_URL = '/'
+LOGIN_REDIRECT_URL = '/workspaces/me/'
 LOGOUT_REDIRECT_URL = '/accounts/login/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/config/urls.py
+++ b/config/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('finance/', include('finance.urls')),
     path('complaints/', include('complaints.urls')),
     path('dashboard/', include('dashboard.urls')),
+    path('workspaces/', include('workspaces.urls')),
     path('audit/', include('audit.urls')),
     path('accounts/', include('accounts.urls')),
     path('admin/', admin.site.urls),

--- a/templates/workspaces/actuaire.html
+++ b/templates/workspaces/actuaire.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace Actuaire</h1>
+<div class="actions">
+  <a href="{% url 'catalog:product_create' %}">Nouveau produit</a>
+  <a href="{% url 'catalog:coverage_create' %}">Nouvelle garantie</a>
+  <a href="{% url 'catalog:product_list' %}">Liste produits/garanties</a>
+</div>
+<h2>Produits actifs</h2>
+<table class="datatable">
+  <thead><tr><th>Nom</th><th>Description</th></tr></thead>
+  <tbody>
+  {% for product in active_products %}
+    <tr><td>{{ product.name }}</td><td>{{ product.description }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Garanties par produit</h2>
+<table class="datatable">
+  <thead><tr><th>Produit</th><th>Nombre de garanties</th></tr></thead>
+  <tbody>
+  {% for item in coverage_counts %}
+    <tr><td>{{ item.name }}</td><td>{{ item.coverage_count }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/workspaces/commercial.html
+++ b/templates/workspaces/commercial.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace Commercial</h1>
+<div class="actions">
+  <a href="{% url 'crm:insured_create' %}">Nouvel assuré</a>
+  <a href="{% url 'underwriting:policy_create' %}">Nouveau contrat</a>
+  <a href="#">Imports Excel</a>
+  <a href="{% url 'complaints:complaint_create' %}">Déposer une plainte</a>
+</div>
+<h2>Assurés créés récemment</h2>
+<table class="datatable">
+  <thead><tr><th>Code</th><th>Nom</th></tr></thead>
+  <tbody>
+  {% for insured in recent_insured %}
+    <tr><td>{{ insured.code }}</td><td>{{ insured.full_name }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Contrats en DRAFT</h2>
+<table class="datatable">
+  <thead><tr><th>Numéro</th><th>Assuré</th></tr></thead>
+  <tbody>
+  {% for policy in draft_policies %}
+    <tr><td>{{ policy.policy_number }}</td><td>{{ policy.insured.full_name }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Contrats à échéance J-30/J-7</h2>
+<table class="datatable">
+  <thead><tr><th>Numéro</th><th>Fin</th></tr></thead>
+  <tbody>
+  {% for policy in expiring_policies %}
+    <tr><td>{{ policy.policy_number }}</td><td>{{ policy.end_date }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/workspaces/comptable.html
+++ b/templates/workspaces/comptable.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace Comptable</h1>
+<div class="actions">
+  <a href="#">Primes à encaisser</a>
+  <a href="{% url 'finance:receipt_list' %}">Encaisser une prime</a>
+  <a href="{% url 'finance:payment_list' %}">Paiements sinistres en attente</a>
+</div>
+<h2>Primes à encaisser</h2>
+<table class="datatable">
+  <thead><tr><th>Contrat</th><th>Montant</th></tr></thead>
+  <tbody>
+  {% for premium in due_premiums %}
+    <tr><td>{{ premium.policy.policy_number }}</td><td>{{ premium.amount_due }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucune</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Sinistres approuvés non payés</h2>
+<table class="datatable">
+  <thead><tr><th>Code</th><th>Montant</th></tr></thead>
+  <tbody>
+  {% for claim in approved_claims %}
+    <tr><td>{{ claim.public_code }}</td><td>{{ claim.reimbursable_amount }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/workspaces/dg.html
+++ b/templates/workspaces/dg.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace DG</h1>
+<p><a href="{% url 'dashboard:dg_dashboard' %}">Aller au dashboard DG</a></p>
+{% endblock %}

--- a/templates/workspaces/gestionnaire.html
+++ b/templates/workspaces/gestionnaire.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace Gestionnaire</h1>
+<div class="actions">
+  <a href="{% url 'claims:claim_list' %}">Sinistres SUBMITTED</a>
+  <a href="{% url 'complaints:complaint_list' %}">Plaintes à répondre</a>
+  <a href="{% url 'complaints:complaint_list' %}">SLA en retard</a>
+</div>
+<h2>Sinistres soumis</h2>
+<table class="datatable">
+  <thead><tr><th>Code</th><th>Assuré</th></tr></thead>
+  <tbody>
+  {% for claim in submitted_claims %}
+    <tr><td>{{ claim.public_code }}</td><td>{{ claim.policy.insured.full_name }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Plaintes ouvertes</h2>
+<table class="datatable">
+  <thead><tr><th>Assuré</th><th>Date</th></tr></thead>
+  <tbody>
+  {% for complaint in open_complaints %}
+    <tr><td>{{ complaint.insured.full_name }}</td><td>{{ complaint.filed_at }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucune</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Alertes SLA</h2>
+<table class="datatable">
+  <thead><tr><th>Assuré</th><th>Date</th></tr></thead>
+  <tbody>
+  {% for complaint in sla_alerts %}
+    <tr><td>{{ complaint.insured.full_name }}</td><td>{{ complaint.filed_at }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucune</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/workspaces/redacteur.html
+++ b/templates/workspaces/redacteur.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace Rédacteur</h1>
+<div class="actions">
+  <a href="{% url 'claims:claim_create' %}">Déclarer un sinistre</a>
+  <a href="{% url 'claims:claim_list' %}">Mes brouillons</a>
+  <a href="{% url 'claims:claim_list' %}">Mes dépôts du jour</a>
+</div>
+<h2>Sinistres soumis</h2>
+<table class="datatable">
+  <thead><tr><th>Code</th><th>Police</th></tr></thead>
+  <tbody>
+  {% for claim in my_claims %}
+    <tr><td>{{ claim.public_code }}</td><td>{{ claim.policy.policy_number }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+<h2>Déclarations du jour</h2>
+<table class="datatable">
+  <thead><tr><th>Code</th><th>Heure</th></tr></thead>
+  <tbody>
+  {% for claim in today_claims %}
+    <tr><td>{{ claim.public_code }}</td><td>{{ claim.declared_at }}</td></tr>
+  {% empty %}
+    <tr><td colspan="2">Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/workspaces/rh.html
+++ b/templates/workspaces/rh.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Espace RH</h1>
+<div class="actions">
+  <a href="/admin/auth/user/add/">Créer un utilisateur (admin)</a>
+  <a href="/admin/auth/user/">Liste des utilisateurs</a>
+  <a href="/admin/accounts/userprofile/?require_password_change__exact=1">Profils à forcer changement MDP</a>
+</div>
+<p>Utilisateurs qui doivent changer leur mot de passe: {{ password_change_required_count }}</p>
+<table class="datatable">
+  <thead><tr><th>Utilisateur</th></tr></thead>
+  <tbody>
+  {% for profile in profiles %}
+    <tr><td>{{ profile.user.username }}</td></tr>
+  {% empty %}
+    <tr><td>Aucun</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/workspaces/apps.py
+++ b/workspaces/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WorkspacesConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "workspaces"

--- a/workspaces/tests.py
+++ b/workspaces/tests.py
@@ -1,0 +1,51 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "group_name,expected",
+    [
+        ("dg", "/dashboard/dg/"),
+        ("rh", "/workspaces/rh/"),
+        ("actuaire", "/workspaces/actuaire/"),
+        ("commercial", "/workspaces/commercial/"),
+        ("redacteur", "/workspaces/redacteur/"),
+        ("gestionnaire", "/workspaces/gestionnaire/"),
+        ("comptable", "/workspaces/comptable/"),
+    ],
+)
+def test_post_login_redirects(client, django_user_model, group_name, expected):
+    user = django_user_model.objects.create_user(username=group_name, password="pwd")
+    user.userprofile.require_password_change = False
+    user.userprofile.save()
+    group, _ = Group.objects.get_or_create(name=group_name)
+    user.groups.add(group)
+    client.force_login(user)
+    response = client.get(reverse("workspaces:me"))
+    assert response.status_code == 302
+    assert response.url == expected
+
+
+@pytest.mark.django_db
+def test_post_login_redirect_default(client, django_user_model):
+    user = django_user_model.objects.create_user(username="no-role", password="pwd")
+    user.userprofile.require_password_change = False
+    user.userprofile.save()
+    client.force_login(user)
+    response = client.get(reverse("workspaces:me"))
+    assert response.status_code == 302
+    assert response.url == "/"
+
+
+@pytest.mark.django_db
+def test_role_required_mixin(client, django_user_model):
+    user = django_user_model.objects.create_user(username="test", password="pwd")
+    user.userprofile.require_password_change = False
+    user.userprofile.save()
+    client.force_login(user)
+    assert client.get(reverse("workspaces:rh")).status_code == 403
+    group, _ = Group.objects.get_or_create(name="rh")
+    user.groups.add(group)
+    assert client.get(reverse("workspaces:rh")).status_code == 200

--- a/workspaces/urls.py
+++ b/workspaces/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from accounts.views import PostLoginRedirectView
+from . import views
+
+app_name = "workspaces"
+
+urlpatterns = [
+    path("dg/", views.DGWorkspaceView.as_view(), name="dg"),
+    path("rh/", views.RHWorkspaceView.as_view(), name="rh"),
+    path("actuaire/", views.ActuaireWorkspaceView.as_view(), name="actuaire"),
+    path("commercial/", views.CommercialWorkspaceView.as_view(), name="commercial"),
+    path("redacteur/", views.RedacteurWorkspaceView.as_view(), name="redacteur"),
+    path("gestionnaire/", views.GestionnaireWorkspaceView.as_view(), name="gestionnaire"),
+    path("comptable/", views.ComptableWorkspaceView.as_view(), name="comptable"),
+    path("me/", PostLoginRedirectView.as_view(), name="me"),
+]

--- a/workspaces/views.py
+++ b/workspaces/views.py
@@ -1,0 +1,104 @@
+from datetime import timedelta
+
+from django.db.models import Count
+from django.utils import timezone
+from django.views.generic import TemplateView
+
+from accounts.models import UserProfile
+from accounts.permissions import RoleRequiredMixin
+from catalog.models import Product
+from complaints.models import Complaint
+from crm.models import Insured
+from claims.models import Claim
+from finance.models import Premium
+from underwriting.models import Policy
+
+
+class DGWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/dg.html"
+    required_roles = ("dg",)
+
+
+class RHWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/rh.html"
+    required_roles = ("rh",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        profiles = UserProfile.objects.filter(require_password_change=True)[:10]
+        context["profiles"] = profiles
+        context["password_change_required_count"] = profiles.count()
+        return context
+
+
+class ActuaireWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/actuaire.html"
+    required_roles = ("actuaire",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["active_products"] = Product.objects.filter(is_active=True)[:5]
+        context["coverage_counts"] = (
+            Product.objects.annotate(coverage_count=Count("coverages"))
+            .values("name", "coverage_count")[:5]
+        )
+        return context
+
+
+class CommercialWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/commercial.html"
+    required_roles = ("commercial",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        today = timezone.now().date()
+        context["recent_insured"] = Insured.objects.order_by("-created_at")[:5]
+        context["draft_policies"] = Policy.objects.filter(status=Policy.Status.DRAFT)[:5]
+        context["expiring_policies"] = Policy.objects.filter(
+            end_date__range=(today + timedelta(days=7), today + timedelta(days=30))
+        )[:5]
+        return context
+
+
+class RedacteurWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/redacteur.html"
+    required_roles = ("redacteur",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        user = self.request.user
+        context["my_claims"] = Claim.objects.filter(status=Claim.Status.SUBMITTED)[:5]
+        context["today_claims"] = Claim.objects.filter(
+            declared_at__date=timezone.now().date()
+        )[:5]
+        return context
+
+
+class GestionnaireWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/gestionnaire.html"
+    required_roles = ("gestionnaire",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["submitted_claims"] = Claim.objects.filter(status=Claim.Status.SUBMITTED)[:5]
+        context["open_complaints"] = Complaint.objects.filter(status=Complaint.Status.OPEN)[:5]
+        context["sla_alerts"] = Complaint.objects.filter(
+            status=Complaint.Status.OPEN,
+            filed_at__lt=timezone.now() - timedelta(days=7),
+        )[:5]
+        return context
+
+
+class ComptableWorkspaceView(RoleRequiredMixin, TemplateView):
+    template_name = "workspaces/comptable.html"
+    required_roles = ("comptable",)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["due_premiums"] = Premium.objects.filter(
+            status__in=[Premium.Status.DUE, Premium.Status.PARTIALLY_PAID]
+        )[:5]
+        context["approved_claims"] = Claim.objects.filter(
+            status=Claim.Status.APPROVED, payments__isnull=True
+        )[:5]
+        return context


### PR DESCRIPTION
## Summary
- add `workspaces` app with role-restricted dashboards
- redirect users after login based on group membership
- templates for DG, RH, actuary, commercial, redactor, manager and accountant workspaces

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4fbfbbe748324ad7f5156ef538151